### PR TITLE
moved root folder gxa-data-migration to index-gxa

### DIFF
--- a/bin/index_analytics.sh
+++ b/bin/index_analytics.sh
@@ -14,7 +14,7 @@ scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 
 # Set path (this is done at this level since this will be executed directly):
-for mod in gxa-data-migration/bin; do
+for mod in index-gxa/bin; do
   export PATH=$ATLASPROD_PATH/$mod:$PATH
 done
 

--- a/bin/index_bioentities.sh
+++ b/bin/index_bioentities.sh
@@ -9,7 +9,7 @@ scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 
 # Set path (this is done at this level since this will be executed directly):
-for mod in gxa-data-migration/bin; do
+for mod in index-gxa/bin; do
   export PATH=$ATLASPROD_PATH/$mod:$PATH
 done
 

--- a/bin/reindex_analytics_import.sh
+++ b/bin/reindex_analytics_import.sh
@@ -14,7 +14,7 @@ scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 [ ! -z ${EXP_ACC+x} ] || ( echo "Env var EXP_ACC ie. E-*-* needs to be defined." && exit 1 )
 
 # Set path (this is done at this level since this will be executed directly):
-for mod in gxa-data-migration/bin; do
+for mod in index-gxa/bin; do
   export PATH=$ATLASPROD_PATH/$mod:$PATH
 done
 

--- a/bin/update_coexpressions.sh
+++ b/bin/update_coexpressions.sh
@@ -9,7 +9,7 @@ scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 
 # Set path (this is done at this level since this will be executed directly):
-for mod in gxa-data-migration/bin; do
+for mod in index-gxa/bin; do
   export PATH=$ATLASPROD_PATH/$mod:$PATH
 done
 

--- a/bin/update_experiment_designs.sh
+++ b/bin/update_experiment_designs.sh
@@ -9,7 +9,7 @@ scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 
 # Set path (this is done at this level since this will be executed directly):
-for mod in gxa-data-migration/bin; do
+for mod in index-gxa/bin; do
   export PATH=$ATLASPROD_PATH/$mod:$PATH
 done
 


### PR DESCRIPTION
In this PR,
- Rename folder name within scripts. This went unnoticed during creation of submodules. 
`gxa-data-migration` to `index-gxa`