### PR TITLE
update variable name to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ export SOLR_HOST=localhost:8983
 delete_gxa_analytics_index.sh
 ```
 
+## Check the number of entries per experiment in the Solr index
+To make sure experiments have a sufficient number of matches in the index, run  
+```
+bin/gxa-index-check-experiments.sh
+```
+This script expects the following variables to be defined: 
+- `EXPERIMENT_ID`: one or more experiment accessions for which index state should be checked
+- `EXP_MATCH_MIN`: minimal accepted number of matches per experiment
+- `EXP_MATCH_WARNING`: fewer matches than this number cause a warning 
+- `EXPERIMENT_TYPE`: gxa or bulk 
+
 ## Tests
 Tests are located in the `tests` directory and use bats. To run them, execute `bash tests/run-tests.sh`. The `tests` folder includes example data in tsv (a condensed SDRF) and in JSON (as it should be produced by the first step that translates the cond. SDRF to JSON).
 

--- a/bin/gxa-index-check-experiments.sh
+++ b/bin/gxa-index-check-experiments.sh
@@ -2,7 +2,7 @@
 # check the health of experiments
 
 [ ! -z ${SOLR_HOST+x} ] || ( echo "Env var SOLR_HOST needs to be defined." && exit 1 )
-[ ! -z ${ACCESSION_LIST+x} ] || (echo "Env var ACCESSION_LIST needs to be defined." && exit 1)
+[ ! -z ${EXPERIMENT_ID+x} ] || (echo "Env var EXPERIMENT_ID needs to be defined." && exit 1)
 [ ! -z ${EXP_MATCH_MIN+x} ] || (echo "Env var EXP_MATCH_MIN needs to be defined." && exit 1)
 [ ! -z ${EXP_MATCH_WARNING+x} ] || (echo "Env var EXP_MATCH_WARN needs to be defined." && exit 1)
 [ ! -z ${EXPERIMENT_TYPE+x} ] || (echo "Env var EXPERIMENT_TYPE needs to be defined." && exit 1)
@@ -14,7 +14,7 @@ if [[ "$status" -ne "0" ]]; then
     echo $out
     exit 1
 fi 
-for exp in $ACCESSION_LIST; do
+for exp in $EXPERIMENT_ID; do
     n_entries=$(echo "$out" | grep -A 1 $exp | egrep -o '"numFound":[0-9]+' | egrep -o "[0-9]+")
     if [[ $n_entries -lt $EXP_MATCH_MIN ]]; then
         echo "Error: experiment $exp has $n_entries entries which is below the minimum of $EXP_MATCH_MIN."

--- a/bin/gxa-index-check-experiments.sh
+++ b/bin/gxa-index-check-experiments.sh
@@ -2,7 +2,7 @@
 # check the health of experiments
 
 [ ! -z ${SOLR_HOST+x} ] || ( echo "Env var SOLR_HOST needs to be defined." && exit 1 )
-[ ! -z ${ATLAS_EXPS+x} ] || (echo "Env var ATLAS_EXPS needs to be defined." && exit 1)
+[ ! -z ${ACCESSION_LIST+x} ] || (echo "Env var ACCESSION_LIST needs to be defined." && exit 1)
 [ ! -z ${EXP_MATCH_MIN+x} ] || (echo "Env var EXP_MATCH_MIN needs to be defined." && exit 1)
 [ ! -z ${EXP_MATCH_WARNING+x} ] || (echo "Env var EXP_MATCH_WARN needs to be defined." && exit 1)
 [ ! -z ${EXPERIMENT_TYPE+x} ] || (echo "Env var EXPERIMENT_TYPE needs to be defined." && exit 1)
@@ -14,7 +14,7 @@ if [[ "$status" -ne "0" ]]; then
     echo $out
     exit 1
 fi 
-for exp in $ATLAS_EXPS; do
+for exp in $ACCESSION_LIST; do
     n_entries=$(echo "$out" | grep -A 1 $exp | egrep -o '"numFound":[0-9]+' | egrep -o "[0-9]+")
     if [[ $n_entries -lt $EXP_MATCH_MIN ]]; then
         echo "Error: experiment $exp has $n_entries entries which is below the minimum of $EXP_MATCH_MIN."

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -144,7 +144,7 @@ setup() {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping load to SOLR"
   fi
-  export ATLAS_EXPS=E-MTAB-6870
+  export EXPERIMENT_ID=E-MTAB-6870
   export EXP_MATCH_MIN=999999999
   export EXP_MATCH_WARNING=100
   export EXPERIMENT_TYPE="gxa"


### PR DESCRIPTION
- Due to collision in variables names, we need to rename `$ATLAS_EXPS` to `$EXPERIMENT_ID ` 
- Corresponding changes will also be made in Jenkins job that invokes the script