### PR TITLE
Consider failures in analytics

### DIFF
--- a/bin/load_analytics_files_in_Solr.sh
+++ b/bin/load_analytics_files_in_Solr.sh
@@ -14,6 +14,10 @@ if [[ "$ACCESSIONS" == *","* ]]; then
   ACCESSIONS=$( echo $ACCESSIONS | sed 's/,/ /g')
 fi
 
+if [ ! -z ${failed_accessions_output+x} ]; then
+  rm -f $failed_accessions_output
+  touch $failed_accessions_output 
+fi
 for EXP_ID in $ACCESSIONS; do
   export EXP_ID # needed for delete to see it
   if [ ! -z ${delete_existing+x} ]; then
@@ -22,6 +26,9 @@ for EXP_ID in $ACCESSIONS; do
   INPUT_JSONL=${analytics_jsonl_dir}/${EXP_ID}.jsonl SOLR_COLLECTION=bulk-analytics SCHEMA_VERSION=1 solr-jsonl-chunk-loader.sh  # SOLR_COLLECTION=bulk-analytics SOLR_PROCESSORS=dedupe
   if [ $? -ne 0 ]; then
     echo "Loading JSONL to $SOLR_HOST failed for $EXP_ID"
+    if [ -f $failed_accessions_output ]; then
+      echo $EXP_ID >> $failed_accessions_output
+    fi
     failed=1
   fi
 done


### PR DESCRIPTION
For a better resume ability in snakemake, this adds support for recording on which specific accession a load to the analytics index failed. With this, on resumming for chunks of accessions, only the ones that are missing in the chunk get redone and not all of them.